### PR TITLE
Update URL for 0.4.2

### DIFF
--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,6 +1,6 @@
 [wrap-file]
 directory = libspng-0.4.2
 
-source_url = https://libspng.org/libspng-0.4.2.zip
+source_url = https://gitlab.com/randy408/libspng/uploads/e3efeb324a336d851d379ab980719400/libspng-0.4.2.zip
 source_filename = libspng-0.4.2.zip
 source_hash = 7786a5d5b35bc871527c866c9a07f54d475261b32e876c7d264805a9e768c1fe


### PR DESCRIPTION
All releases are hosted on GitLab, v0.4.2 was uploaded to the site as a workaround when GitLab upload functionality was broken.